### PR TITLE
Ensure only one colon in image name for CI push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-fv3config-cache
+      - gcp-gcr/gcr-auth
       - run: 
           name: "Compile model and perform model tests"
           command: |
@@ -71,7 +72,6 @@ jobs:
           name: "Build documentation"
           command: |
             make docs-docker
-      - gcp-gcr/gcr-auth
       - run: |
           echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://gcr.io
           if [[ "$CIRCLE_BRANCH" == "master" ]]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       docker_layer_caching: true
       image: ubuntu-1604:201903-01
     environment:
-      GCR_IMAGE: us.gcr.io/vcm-ml/fv3gfs-wrapper
+      GCR_IMAGE: us.gcr.io/vcm-ml/fv3gfs-wrapper:gnu7-mpich314-nocuda
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
       - gcp-cli/install:
@@ -78,15 +78,15 @@ jobs:
           then
               echo "pushing untagged image $GCR_IMAGE"
               docker push $GCR_IMAGE
-              echo "pushing image $GCR_IMAGE:$CIRCLE_SHA1"
-              docker tag $GCR_IMAGE $GCR_IMAGE:$CIRCLE_SHA1
-              docker push $GCR_IMAGE:$CIRCLE_SHA1
+              echo "pushing image $GCR_IMAGE-$CIRCLE_SHA1"
+              docker tag $GCR_IMAGE $GCR_IMAGE-$CIRCLE_SHA1
+              docker push $GCR_IMAGE-$CIRCLE_SHA1
           fi
           if [[ ! -z "$CIRCLE_TAG" ]]
           then
-              echo "pushing tagged image $GCR_IMAGE:$CIRCLE_TAG"
-              docker tag $GCR_IMAGE $GCR_IMAGE:$CIRCLE_TAG
-              docker push $GCR_IMAGE:$CIRCLE_TAG
+              echo "pushing tagged image $GCR_IMAGE-$CIRCLE_TAG"
+              docker tag $GCR_IMAGE $GCR_IMAGE-$CIRCLE_TAG
+              docker push $GCR_IMAGE-$CIRCLE_TAG
           fi
       - run:
           name: "Delete data files"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           name: "save gcloud key for gcsfs"
           command: |
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+            echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GCR_KEY | base64 --decode)" >> $BASH_ENV
       - add_ssh_keys:
           fingerprints:
             - "dd:76:98:a1:2c:ec:29:0d:7e:3e:fd:57:c5:4e:a2:8f"  # github user key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       docker_layer_caching: true
       image: ubuntu-1604:201903-01
     environment:
-      GCR_IMAGE: us.gcr.io/vcm-ml/fv3gfs-wrapper:gnu7-mpich314-nocuda
+      GCR_IMAGE: us.gcr.io/vcm-ml/fv3gfs-wrapper
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     steps:
       - gcp-cli/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
           name: "save gcloud key for gcsfs"
           command: |
             echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-            echo "export GCLOUD_SERVICE_KEY=\$(echo \$ENCODED_GCR_KEY | base64 --decode)" >> $BASH_ENV
       - add_ssh_keys:
           fingerprints:
             - "dd:76:98:a1:2c:ec:29:0d:7e:3e:fd:57:c5:4e:a2:8f"  # github user key

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,9 +29,9 @@ entrypoints==0.3
 f90nml==1.1.2
 fasteners==0.15
 flake8==3.7.8
-fsspec==0.8.0
-fv3config==0.7.1
-gcsfs==0.7.0
+fsspec==2021.11.0
+fv3config==0.8.0
+gcsfs==2021.11.0
 google-api-core==1.22.1
 google-auth-oauthlib==0.4.1
 google-auth==1.20.1

--- a/tests/pytest/requirements.txt
+++ b/tests/pytest/requirements.txt
@@ -9,7 +9,7 @@ Sphinx==1.8.5
 twine==1.14.0
 Click==7.0
 f90nml>=1.1.0
-fv3config==0.5.1
+fv3config==0.8.0
 appdirs>=1.4.0
 requests
 sphinx_rtd_theme


### PR DESCRIPTION
Currently the CI rule for pushing the image [fails](https://app.circleci.com/pipelines/github/VulcanClimateModeling/fv3gfs-wrapper/1622/workflows/9821992d-f27e-4b75-bfb6-02f99719614f/jobs/3299) because the image is named

`us.gcr.io/vcm-ml/fv3gfs-wrapper:gnu7-mpich314-nocuda:{SHA1}` which is not a valid docker image name (there are two colons). This PR replaces the second colon with a dash. So the tag will be `gnu7-mpich314-nocuda-{SHA1}`

Since the last time the tests for this repo passed, there have been some changes related to auth for accessing data on the gs://vcm-fv3config bucket. So there are also some auth-related changes and version bumps for fv3config/gcsfs/fsspec.

Resolves #296 